### PR TITLE
fix:bug for pushBack on empty list

### DIFF
--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -8,6 +8,10 @@ type List[T any] struct {
 	Head Node[T]
 }
 
+func (l *List[T]) setNext(node Node[T]) {
+	l.Head = node
+}
+
 func New[T any]() *List[T] {
 	return &List[T]{
 		Head: newEndNode[T](),
@@ -31,7 +35,7 @@ func (l *List[T]) PushFront(data T) {
 func (l *List[T]) PushBack(data T) {
 	nn := newNode(data)
 
-	l.Head.pushNext(l.Head, nn)
+	l.Head.pushNext(l, nn)
 }
 
 func (l *List[T]) Filter(fn func(T) bool) []T {

--- a/pkg/list/list_test.go
+++ b/pkg/list/list_test.go
@@ -1,17 +1,40 @@
-package list_test
+package list
 
 import (
 	"testing"
+	)
 
-	"github.com/1995parham/linkedlist/pkg/list"
-)
-
-func TestListWith3Member(t *testing.T) {
-	l := list.New[int]()
+func TestListWith2Members(t *testing.T) {
+	l := New[int]()
 	l.PushFront(10)
 	l.PushFront(20)
 
 	if l.Len() != 2 {
 		t.Errorf("list should have 2 items but have %d items in it", l.Len())
+	}
+	first := l.Head.(Node[int])
+	if getData[int](first) != 20 {
+		t.Errorf("first item should be 20")
+	}
+	if getData[int](first.next()) != 10 {
+		t.Errorf("next item should be 10")
+	}
+}
+
+
+func TestListWith2MembersBack(t *testing.T) {
+	l := New[int]()
+	l.PushBack(10)
+	l.PushBack(20)
+
+	if l.Len() != 2 {
+		t.Errorf("list should have 2 items but have %d items in it", l.Len())
+	}
+	first := l.Head.(Node[int])
+	if getData[int](first) != 10 {
+		t.Errorf("first item should be 10")
+	}
+	if getData[int](first.next()) != 20 {
+		t.Errorf("next item should be 20")
 	}
 }

--- a/pkg/list/list_test.go
+++ b/pkg/list/list_test.go
@@ -5,7 +5,7 @@ import (
 	)
 
 func TestListWith2Members(t *testing.T) {
-	l := New[int]()
+	var l *List[int] = New[int]()
 	l.PushFront(10)
 	l.PushFront(20)
 
@@ -37,4 +37,11 @@ func TestListWith2MembersBack(t *testing.T) {
 	if getData[int](first.next()) != 20 {
 		t.Errorf("next item should be 20")
 	}
+}
+
+
+func TestListIsLinker(t *testing.T) {
+	//test for interface implementation
+	var _ Linker[interface{}] = &List[interface{}]{}
+	var _ Linker[interface{}] = New[interface{}]()
 }

--- a/pkg/list/node.go
+++ b/pkg/list/node.go
@@ -1,10 +1,15 @@
 package list
 
+
+type Linker[T any] interface {
+	setNext(Node[T])
+}
+
 type Node[T any] interface {
-	pushNext(last, new Node[T])
+	Linker[T]
+	pushNext(last Linker[T], new Node[T])
 	valid() bool
 	next() Node[T]
-	setNext(Node[T])
 }
 
 type node[T any] struct {
@@ -19,7 +24,7 @@ func newNode[T any](data T) *node[T] {
 	}
 }
 
-func (n *node[T]) pushNext(_, new Node[T]) {
+func (n *node[T]) pushNext(_ Linker[T], new Node[T]) {
 	n.Next.pushNext(n, new)
 }
 
@@ -53,7 +58,7 @@ func (e *endNode[T]) setNext(Node[T]) {
 	return
 }
 
-func (e *endNode[T]) pushNext(previous, new Node[T]) {
+func (e *endNode[T]) pushNext(previous Linker[T], new Node[T]) {
 	previous.setNext(new)
 	new.setNext(e)
 }

--- a/pkg/list/node_test.go
+++ b/pkg/list/node_test.go
@@ -5,7 +5,8 @@ import (
 )
 
 func TestNewNode(t *testing.T) {
-	n := newNode[int](10)
+	//test for interface implementation
+	var n Node[int] = newNode[int](10)
 
 	if n.valid() != true {
 		t.Errorf("node must be valid")
@@ -13,7 +14,8 @@ func TestNewNode(t *testing.T) {
 }
 
 func TestNewEndNode(t *testing.T) {
-	n := newEndNode[int]()
+	//test for interface implementation
+	var n Node[int] = newEndNode[int]()
 
 	if n.valid() != false {
 		t.Errorf("end node must be invalid")

--- a/pkg/list/node_test.go
+++ b/pkg/list/node_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNewNode(t *testing.T) {
-	n := newNode(10)
+	n := newNode[int](10)
 
 	if n.valid() != true {
 		t.Errorf("node must be valid")


### PR DESCRIPTION
I came back to this and realised that pushBack didn't work for the case of an empty List (only endNode)

Here is a fix, and some minor changes (check for interface implementations also package rename)